### PR TITLE
버그수정

### DIFF
--- a/XVIBE_TextRPG/BattlePhase.cs
+++ b/XVIBE_TextRPG/BattlePhase.cs
@@ -22,6 +22,11 @@ namespace XVIBE_TextRPG
             {
                 case "1":
                     Console.WriteLine("초급 던전으로 입장합니다.");
+                    if(Player.CurrentHP == 0)
+                    {
+                        Console.WriteLine("체력이 부족하여 던전에 입장할 수 없습니다.");
+                        return;
+                    }
                     Console.WriteLine("던전 입장 중...");
                     System.Threading.Thread.Sleep(2000); // 2초 대기
                     EasyDeonseon easyDungeon = new EasyDeonseon();

--- a/XVIBE_TextRPG/PlayerSettings.cs
+++ b/XVIBE_TextRPG/PlayerSettings.cs
@@ -172,6 +172,7 @@ namespace XVIBE_TextRPG
             }
 
             Console.Clear();
+            Player.UpdateStats(); // 직업에 따라 스탯 업데이트
             return Player.Job;
         }
     }


### PR DESCRIPTION
직업에 맞지 않는 스탯이 적용되는 버그는 스탯 적용시키는 메서드를 불러와서 해결.
체력이 0이면 던전 입장 불가한 이프문을 추가했지만 체력이 0이면 게임오버가 되는걸로 제작 방향이 결정되면 저 부분은 제거를 해도 돼요